### PR TITLE
partition: fix mount failure after FBE metadata decryption

### DIFF
--- a/partition.cpp
+++ b/partition.cpp
@@ -700,6 +700,7 @@ void TWPartition::Setup_Data_Partition(bool Display_Error) {
 	if (strcmp(crypto_blkdev, "error") != 0) {
 		Set_FBE_Status();
 		Decrypted_Block_Device = crypto_blkdev;
+		Is_Decrypted = true;
 		LOGINFO("Data already decrypted, new block device: '%s'\n", crypto_blkdev);
 		#ifndef TW_PREPARE_DATA_MEDIA_EARLY
 		if (datamedia)

--- a/partitionmanager.cpp
+++ b/partitionmanager.cpp
@@ -2026,7 +2026,7 @@ void TWPartitionManager::Post_Decrypt(const string& Block_Device) {
 			gui_msg(Msg("decrypt_success_dev=Data successfully decrypted, new block device: '{1}'")(Block_Device));
 		} else {
 			std::string crypto_blkdev = android::base::GetProperty("ro.crypto.fs_crypto_blkdev", "");
-			if (!crypto_blkdev.empty()) {
+			if (!crypto_blkdev.empty() && crypto_blkdev != "error") {
 				dat->Decrypted_Block_Device = crypto_blkdev;
 				gui_msg(Msg("decrypt_success_dev=Data successfully decrypted, new block device: '{1}'")(crypto_blkdev));
 			} else {
@@ -2065,7 +2065,6 @@ void TWPartitionManager::Post_Decrypt(const string& Block_Device) {
 	} else
 		LOGERR("Unable to locate data partition.\n");
 }
-
 
 void TWPartitionManager::Parse_Users() {
 #ifdef TW_INCLUDE_FBE
@@ -2180,6 +2179,10 @@ int TWPartitionManager::Decrypt_Device(string Password, int user_id) {
 
 	if (DataManager::GetIntValue(TW_IS_FBE)) {
 #ifdef TW_INCLUDE_FBE
+		TWPartition* dat = Find_Partition_By_Path("/data");
+		if (dat && !dat->Decrypted_Block_Device.empty()) {
+		dat->Is_Decrypted = true;
+		}
 		if (!Mount_By_Path("/data", true)) // /data has to be mounted for FBE
 			return -1;
 

--- a/partitionmanager.cpp
+++ b/partitionmanager.cpp
@@ -2181,7 +2181,7 @@ int TWPartitionManager::Decrypt_Device(string Password, int user_id) {
 #ifdef TW_INCLUDE_FBE
 		TWPartition* dat = Find_Partition_By_Path("/data");
 		if (dat && !dat->Decrypted_Block_Device.empty()) {
-		dat->Is_Decrypted = true;
+			dat->Is_Decrypted = true;
 		}
 		if (!Mount_By_Path("/data", true)) // /data has to be mounted for FBE
 			return -1;

--- a/partitionmanager.cpp
+++ b/partitionmanager.cpp
@@ -2025,7 +2025,13 @@ void TWPartitionManager::Post_Decrypt(const string& Block_Device) {
 			dat->Decrypted_Block_Device = Block_Device;
 			gui_msg(Msg("decrypt_success_dev=Data successfully decrypted, new block device: '{1}'")(Block_Device));
 		} else {
-			gui_msg("decrypt_success_nodev=Data successfully decrypted");
+			std::string crypto_blkdev = android::base::GetProperty("ro.crypto.fs_crypto_blkdev", "");
+			if (!crypto_blkdev.empty()) {
+				dat->Decrypted_Block_Device = crypto_blkdev;
+				gui_msg(Msg("decrypt_success_dev=Data successfully decrypted, new block device: '{1}'")(crypto_blkdev));
+			} else {
+				gui_msg("decrypt_success_nodev=Data successfully decrypted");
+			}
 		}
 		property_set("twrp.decrypt.done", "true");
 		dat->Setup_File_System(false);
@@ -2059,6 +2065,7 @@ void TWPartitionManager::Post_Decrypt(const string& Block_Device) {
 	} else
 		LOGERR("Unable to locate data partition.\n");
 }
+
 
 void TWPartitionManager::Parse_Users() {
 #ifdef TW_INCLUDE_FBE


### PR DESCRIPTION
When FBE metadata decryption succeeds, Post_Decrypt is called with an
empty Block_Device, leaving Decrypted_Block_Device unset. This causes
Find_Actual_Block_Device() to fall back to the raw block device instead
of the mapped dm device, resulting in mount failure.

Changes:
- partition.cpp: set Is_Decrypted when ro.crypto.fs_crypto_blkdev is
  already set on partition initialization
- partitionmanager.cpp: populate Decrypted_Block_Device from
  ro.crypto.fs_crypto_blkdev in Post_Decrypt when Block_Device is empty
- partitionmanager.cpp: restore Is_Decrypted before mounting /data in
  Decrypt_Device, as Decrypt_FBE_DE resets it to false after DE decryption